### PR TITLE
fix: add .js extensions to API imports for Vercel serverless functions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -14,7 +14,10 @@
       "Bash(git push:*)",
       "Bash(git commit:*)",
       "Bash(git checkout:*)",
-      "Bash(npm run build:*)"
+      "Bash(npm run build:*)",
+      "Bash(git merge:*)",
+      "Bash(git stash:*)",
+      "Bash(git pull:*)"
     ],
     "deny": [],
     "ask": []

--- a/api/lib/services/tesseract.service.ts
+++ b/api/lib/services/tesseract.service.ts
@@ -1,7 +1,7 @@
 import { createWorker, Worker } from 'tesseract.js';
-import { PlayerData } from '../types';
-import { DataParser } from '../utils/dataParser';
-import { ImagePreprocessingService } from './imagePreprocessing.service';
+import type { PlayerData } from '../types/index.js';
+import { DataParser } from '../utils/dataParser.js';
+import { ImagePreprocessingService } from './imagePreprocessing.service.js';
 
 export class TesseractService {
   private worker: Worker | null = null;

--- a/api/lib/utils/dataParser.ts
+++ b/api/lib/utils/dataParser.ts
@@ -1,4 +1,4 @@
-import { PlayerData } from '../types';
+import type { PlayerData } from '../types/index.js';
 
 export class DataParser {
   parseOCRText(text: string): PlayerData[] {

--- a/api/ocr/process.ts
+++ b/api/ocr/process.ts
@@ -1,7 +1,7 @@
 import type { VercelRequest, VercelResponse } from '@vercel/node';
 import multiparty from 'multiparty';
-import { TesseractService } from '../lib/services/tesseract.service';
-import { ProcessImagesResponse } from '../lib/types';
+import { TesseractService } from '../lib/services/tesseract.service.js';
+import type { ProcessImagesResponse } from '../lib/types/index.js';
 
 export const config = {
   api: {


### PR DESCRIPTION
- Fixed TypeScript import errors in API folder
- Added .js extensions to all relative imports
- Changed type imports to use 'import type' syntax
- Ensures serverless functions compile correctly on Vercel

Fixes TypeScript errors:
- TS2834: Relative import paths need explicit file extensions
- TS2307: Cannot find module errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)